### PR TITLE
Prefix error on delete job

### DIFF
--- a/src/Controller/JobController.php
+++ b/src/Controller/JobController.php
@@ -104,6 +104,8 @@ class JobController extends BaseController
     public function deleteAction(string $id, Request $request)
     {
         $this->getDisque($request)->delJob($id);
-        return $this->redirect($this->url->generate('disque_admin_job_index'));
+        return $this->redirect($this->url->generate('disque_admin_job_index', [
+            'prefix' => $request->attributes->get('prefix')
+        ]));
     }
 }


### PR DESCRIPTION
This seems to fix MissingMandatoryParametersException: 'Some mandatory parameters are missing ("prefix") to generate a URL for route "disque_admin_job_index".' on delete.